### PR TITLE
Add functionality to get a basic setup. 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,40 +2,61 @@
 
 ssh_agent: true
 
+display_manager: ""
+display_managers:
+  - "gdm"
+  - "lightdm"
+  - "sddm"
+
+desktop: ""
+  # cinnamon
+  # gnome
+  # kde
+  # xfce
+
 install:
-  cli_tools: true
-  desktop: "none"
-    # cinnamon
-    # gnome
-    # kde
-    # xfce
-    # awesome
+  cli_essential: true
+  cli_useful: false
+  desktop_useful: "{{ desktop | default(false, 'true') | bool }}"
 
-pkgs_useful:
-  - dconf-editor
-  - gnome-disk-utility
-  - gnome-keyring
-  - gnome-screenshot
-  - network-manager-applet
-  - noto-fonts-emoji
-  - polkit-gnome
-  - xautolock
-  - xclip
-  - xcursor-vanilla-dmz
-  - xdg-user-dirs
-  - xorg-xkill
-
-
-cli_tools:
-  - ""
-  - "TOOL"
-  - "TOOL"
-  - "TOOL"
-  - "TOOL"
-  - "TOOL"
-  - "TOOL"
-  - "TOOL"
-  - "TOOL"
-  - "TOOL"
-
-# defaults file for archlinux-setup
+packages:
+  cli_essential:
+    - "bash-completion"
+    - "gzip"
+    - "htop"
+    - "man-db"
+    - "unrar"
+    - "unzip"
+    - "vim"
+  cli_useful:
+    - "bind"
+    - "git"
+    - "glow"
+    - "imagemagick"
+    - "nmap"
+    - "pacman-contrib"
+    - "reflector"
+    - "rsync"
+    - "tree"
+    - "wget"
+  desktop_common:
+    - "archlinux-wallpaper"
+    - "celluloid"
+    - "chromium"
+    - "evolution"
+    - "firefox"
+    - "gedit"
+    - "libreoffice-still"
+    - "noto-fonts-emoji"
+    - "xdg-user-dirs"
+    - "xreader"
+  desktop_useful:
+    - "dconf-editor"
+    - "gnome-disk-utility"
+    - "gnome-keyring"
+    - "gnome-screenshot"
+    - "network-manager-applet"
+    - "polkit-gnome"
+    - "xclip"
+    - "xcursor-vanilla-dmz"
+    - "xorg-xkill"

--- a/files/slick-greeter.conf
+++ b/files/slick-greeter.conf
@@ -1,0 +1,34 @@
+[Greeter]
+# LightDM GTK+ Configuration
+# Available configuration options listed below.
+#
+# activate-numlock=Whether to activate numlock. This features requires the installation of numlockx. (true or false)
+background=/usr/share/backgrounds/archlinux/awesome.png
+# background-color=Background color (e.g. #772953), set before wallpaper is seen
+draw-user-backgrounds=false
+# draw-grid=Whether to draw an overlay grid (true or false)
+# show-hostname=Whether to show the hostname in the menubar (true or false)
+# show-power=Whether to show the power indicator in the menubar (true or false)
+# show-a11y=Whether to show the accessibility options in the menubar (true or false)
+# show-keyboard=Whether to show the keyboard indicator in the menubar (true or false)
+# show-clock=Whether to show the clock in the menubar (true or false)
+# show-quit=Whether to show the quit menu in the menubar (true or false)
+# logo=Logo file to use
+# other-monitors-logo=Logo file to use for other monitors
+# theme-name=GTK+ theme to use
+# icon-theme-name=Icon theme to use
+# font-name=Font to use
+# xft-antialias=Whether to antialias Xft fonts (true or false)
+# xft-dpi=Resolution for Xft in dots per inch
+# xft-hintstyle=What degree of hinting to use (hintnone/hintslight/hintmedium/hintfull)
+# xft-rgba=Type of subpixel antialiasing (none/rgb/bgr/vrgb/vbgr)
+# onscreen-keyboard=Whether to enable the onscreen keyboard (true or false)
+# high-contrast=Whether to use a high contrast theme (true or false)
+# screen-reader=Whether to enable the screen reader (true or false)
+# play-ready-sound=A sound file to play when the greeter is ready
+# hidden-users=List of usernames that are hidden until a special key combination is hit
+# group-filter=List of groups that users must be part of to be shown (empty list shows all users)
+# enable-hidpi=Whether to enable HiDPI support (on/off/auto)
+# only-on-monitor=Sets the monitor on which to show the login window, -1 means "follow the mouse"
+# stretch-background-across-monitors=Whether to stretch the background across multiple monitors (false by default)
+# clock-format=What clock format to use (e.g., %H:%M or %l:%M %p)

--- a/tasks/configure-lightdm.yml
+++ b/tasks/configure-lightdm.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Set up slick-greeter for lightdm
+  lineinfile:
+    path: "/etc/lightdm/lightdm.conf"
+    line: "greeter-session=lightdm-slick-greeter"
+    insertafter: "^#greeter-session=example-gtk-gnome"
+
+- name: Deploy slick-greeter config file
+  copy:
+    src: "files/slick-greeter.conf"
+    dest: "/etc/lightdm/slick-greeter.conf"
+
+
+#/etc/lightdm/slick-greeter.conf

--- a/tasks/install-desktop.yml
+++ b/tasks/install-desktop.yml
@@ -1,0 +1,41 @@
+---
+
+- name: Install desktop packages
+  community.general.pacman:
+    state: "installed"
+    name: "{{ desktop_packages }}"
+
+- name: Install optional dependencies
+  community.general.pacman:
+    state: "installed"
+    name: "{{ desktop_packages_deps }}"
+    reason: "dependency"
+  when: desktop_packages_deps is defined
+
+- name: Install common desktop packages
+  community.general.pacman:
+    state: "installed"
+    name: "{{ packages.desktop_common }}"
+    reason: "dependency"
+
+- name: Configure display manager
+  include_tasks: "configure-{{ display_manager }}.yml"
+
+- name: Disable other display managers and activate desktop's
+  block:
+  - name: Disable other display managers
+    systemd:
+      name: "{{ item }}"
+      enabled: false
+    register: systemd_output
+    # failed_when only valid as long as bug exists that prevents module from determining service status
+    failed_when:
+      - systemd_output.msg is defined
+      - systemd_output.msg != "Service is in unknown state"
+      - not systemd_output.msg is match("Could not find the requested service .*")
+    loop: "{{ display_managers | difference(display_manager) }}"
+
+  - name: Enable corresponding display manager
+    systemd:
+      name: "{{ display_manager }}"
+      enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,12 @@
 
 - name: Update system
   block:
+  - name: Activate multilib repository
+    replace:
+      path: "/etc/pacman.conf"
+      regexp: "^#\\[multilib\\]\n#Include = /etc/pacman\\.d/mirrorlist$"
+      replace: "[multilib]\nInclude = /etc/pacman.d/mirrorlist"
+
   - name: Update package cache (pre)
     community.general.pacman:
       update_cache: yes
@@ -30,7 +36,7 @@
       dest: "/etc/systemd/user/ssh-agent.service"
 
   - name: Enable systemd global user service
-    service:
+    systemd:
       name: "ssh-agent"
       scope: "global"
       enabled: true
@@ -68,31 +74,33 @@
     - username is defined
     - ansible_facts.service_mgr == "systemd"
 
+- name: Install essential cli tools
+  community.general.pacman:
+    state: "present"
+    name: "{{ packages.cli_essential }}"
+  when:
+    - install.cli_essential | bool
 
+- name: Install useful cli tools
+  community.general.pacman:
+    state: "present"
+    name: "{{ packages.cli_useful }}"
+  when:
+    - install.cli_useful | bool
 
-- name: FAIL
-  fail:
+- name: Install useful graphical applications
+  community.general.pacman:
+    state: "present"
+    name: "{{ packages.desktop_useful }}"
+  when:
+    - install.desktop_useful | bool
 
-
-
-
-
-- name: "Include vars for desktop '{{ install.desktop }}'"
+- name: "Include vars for desktop '{{ desktop }}'"
   include_vars: "desktop-{{ desktop }}.yml"
   when:
-    - install.desktop is defined
-    - install.desktop != "none"
+    - desktop != ""
 
-- name: "Include tasks for desktop '{{ install.desktop }}'"
-  include_tasks: "install-desktop-{{ desktop }}.yml"
+- name: "Include tasks for desktop"
+  include_tasks: "install-desktop.yml"
   when:
-    - install.desktop is defined
-    - install.desktop != "none"
-
-
-- name: DEBUG
-  debug:
-    msg: "{{ was }}"
-
-
-# tasks file for archlinux-setup
+    - desktop != ""

--- a/vars/desktop-cinnamon.yml
+++ b/vars/desktop-cinnamon.yml
@@ -1,0 +1,15 @@
+---
+
+display_manager: "lightdm"
+
+desktop_packages: 
+  - "cinnamon"
+  - "cinnamon-translations"
+  - "gnome-terminal"
+  - "lightdm"
+
+desktop_packages_deps: 
+  - "blueman"
+  - "nemo-fileroller"
+  - "system-config-printer"
+  - "lightdm-slick-greeter"


### PR DESCRIPTION
This adds the first step: Getting a basic setup.  
Includes:

- Installation of packages deemed essential (default: `true`)
- Installation of packages deemed useful (default: `false`)
- Installation of packages deemed useful for a graphical environment (default: `true` if `desktop` is chosen)
- Installation of desktop specific packages (default: `false` -> depends on wether a desktop is chosen and supported)

It also is able to deploy the `cinnamon` desktop including a basic setup with `lightdm` and `lightdm-slick-greeter`.  
More **DE**s will follow.